### PR TITLE
[RELEASE] 1.2a.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# **[1.2a.1](https://github.com/accre/lstore-jerasure/tree/ACCRE_1.2a.1)** (2015-10-28)
+
+## Changes ([full changelog](https://github.com/accre/lstore-jerasure/compare/ACCRE_1.2a...ACCRE_1.2a.1))
+*  0387b4d Add blank CHANGELOG for building
+*  b8ba63e Allow overriding the CPack generator on cmdline
+
+


### PR DESCRIPTION
# **[1.2a.1](https://github.com/accre/lstore-jerasure/tree/ACCRE_1.2a.1)** (2015-10-28)
## Changes ([full changelog](https://github.com/accre/lstore-jerasure/compare/ACCRE_1.2a...ACCRE_1.2a.1))
-  0387b4d Add blank CHANGELOG for building
-  b8ba63e Allow overriding the CPack generator on cmdline
